### PR TITLE
Remove Broadcom audio codec blobs

### DIFF
--- a/i9082/i9082-vendor-blobs.mk
+++ b/i9082/i9082-vendor-blobs.mk
@@ -66,22 +66,11 @@ PRODUCT_COPY_FILES += \
     vendor/samsung/i9082/proprietary/lib/lib_Samsung_SB_AM_for_ICS_v03007.so:system/lib/lib_Samsung_SB_AM_for_ICS_v03007.so \
     vendor/samsung/i9082/proprietary/lib/lib_SamsungRec_V01006.so:system/lib/lib_SamsungRec_V01006.so \
     vendor/samsung/i9082/proprietary/lib/lib_SoundAlive_V01013n.so:system/lib/lib_SoundAlive_V01013n.so \
-    vendor/samsung/i9082/proprietary/lib/libaacdecoderwrapper.so:system/lib/libaacdecoderwrapper.so \
     vendor/samsung/i9082/proprietary/lib/libat.so:system/lib/libat.so \
     vendor/samsung/i9082/proprietary/lib/libat_stubs.so:system/lib/libat_stubs.so \
     vendor/samsung/i9082/proprietary/lib/libatlog.so:system/lib/libatlog.so \
     vendor/samsung/i9082/proprietary/lib/libbrcm_ril.so:system/lib/libbrcm_ril.so \
-    vendor/samsung/i9082/proprietary/lib/libbrcmaacenc.so:system/lib/libbrcmaacenc.so \
-    vendor/samsung/i9082/proprietary/lib/libbrcmamrnbaridec.so:system/lib/libbrcmamrnbaridec.so \
-    vendor/samsung/i9082/proprietary/lib/libbrcmamrnbarienc.so:system/lib/libbrcmamrnbarienc.so \
-    vendor/samsung/i9082/proprietary/lib/libbrcmamrwbaridec.so:system/lib/libbrcmamrwbaridec.so \
-    vendor/samsung/i9082/proprietary/lib/libbrcmamrwbarienc.so:system/lib/libbrcmamrwbarienc.so \
     vendor/samsung/i9082/proprietary/lib/libbrcmcutils.so:system/lib/libbrcmcutils.so \
-    vendor/samsung/i9082/proprietary/lib/libbrcmheaacdecoder.so:system/lib/libbrcmheaacdecoder.so \
-    vendor/samsung/i9082/proprietary/lib/libbrcmmp3dec.so:system/lib/libbrcmmp3dec.so \
-    vendor/samsung/i9082/proprietary/lib/libbrcmmp3enc.so:system/lib/libbrcmmp3enc.so \
-    vendor/samsung/i9082/proprietary/lib/libBrcmOMX_Component.so:system/lib/libBrcmOMX_Component.so \
-    vendor/samsung/i9082/proprietary/lib/libBrcmOMX_Core.so:system/lib/libBrcmOMX_Core.so \
     vendor/samsung/i9082/proprietary/lib/libbrcmparser.so:system/lib/libbrcmparser.so \
     vendor/samsung/i9082/proprietary/lib/libbufmgmt.so:system/lib/libbufmgmt.so \
     vendor/samsung/i9082/proprietary/lib/libbufpool.so:system/lib/libbufpool.so \
@@ -99,14 +88,6 @@ PRODUCT_COPY_FILES += \
     vendor/samsung/i9082/proprietary/lib/libmmal_components.so:system/lib/libmmal_components.so \
     vendor/samsung/i9082/proprietary/lib/libmmal_util.so:system/lib/libmmal_util.so \
     vendor/samsung/i9082/proprietary/lib/libmmal_vc.so:system/lib/libmmal_vc.so \
-    vendor/samsung/i9082/proprietary/lib/libOMX.brcm.audio.aac.decoder.so:system/lib/libOMX.brcm.audio.aac.decoder.so \
-    vendor/samsung/i9082/proprietary/lib/libOMX.brcm.audio.aac.encoder.so:system/lib/libOMX.brcm.audio.aac.encoder.so \
-    vendor/samsung/i9082/proprietary/lib/libOMX.brcm.audio.amrnb.decoder.so:system/lib/libOMX.brcm.audio.amrnb.decoder.so \
-    vendor/samsung/i9082/proprietary/lib/libOMX.brcm.audio.amrnb.encoder.so:system/lib/libOMX.brcm.audio.amrnb.encoder.so \
-    vendor/samsung/i9082/proprietary/lib/libOMX.brcm.audio.amrwb.decoder.so:system/lib/libOMX.brcm.audio.amrwb.decoder.so \
-    vendor/samsung/i9082/proprietary/lib/libOMX.brcm.audio.amrwb.encoder.so:system/lib/libOMX.brcm.audio.amrwb.encoder.so \
-    vendor/samsung/i9082/proprietary/lib/libOMX.brcm.audio.mp3.decoder.so:system/lib/libOMX.brcm.audio.mp3.decoder.so \
-    vendor/samsung/i9082/proprietary/lib/libOMX.brcm.audio.mp3.encoder.so:system/lib/libOMX.brcm.audio.mp3.encoder.so \
     vendor/samsung/i9082/proprietary/lib/libomxmmal.so:system/lib/libomxmmal.so \
     vendor/samsung/i9082/proprietary/lib/libril.so:system/lib/libril.so \
     vendor/samsung/i9082/proprietary/lib/librpc.so:system/lib/librpc.so \
@@ -121,7 +102,6 @@ PRODUCT_COPY_FILES += \
     vendor/samsung/i9082/proprietary/lib/libSoundAlive_VSP_ver312a.so:system/lib/libSoundAlive_VSP_ver312a.so \
     vendor/samsung/i9082/proprietary/lib/libsoundspeed.so:system/lib/libsoundspeed.so \
     vendor/samsung/i9082/proprietary/lib/libstagefrighthw.so:system/lib/libstagefrighthw.so \
-    vendor/samsung/i9082/proprietary/lib/libstagefrighthw_a.so:system/lib/libstagefrighthw_a.so \
     vendor/samsung/i9082/proprietary/lib/libsthmb.so:system/lib/libsthmb.so \
     vendor/samsung/i9082/proprietary/lib/libtvservice.so:system/lib/libtvservice.so \
     vendor/samsung/i9082/proprietary/lib/libtvservice_binder.so:system/lib/libtvservice_binder.so \


### PR DESCRIPTION
These audio codecs are not needed anymore in Galaxy Grand Duos GT-i9082.Therefore,it can be safely removed
